### PR TITLE
Add AGENTS.md with cloud-specific development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Invoice Generator is a Flask (Python) web application for creating and managing invoices. It uses SQLite for storage, WeasyPrint for PDF generation, and Jinja2 templates for the UI.
+
+### System dependencies
+
+WeasyPrint requires native C libraries (pango, cairo, gdk-pixbuf, etc.). These are installed via apt and must be present before pip install succeeds. See `Dockerfile.dev` for the canonical list.
+
+### Running the dev server
+
+```bash
+source venv/bin/activate
+export FLASK_APP=app_factory.py
+export FLASK_ENV=development
+mkdir -p instance/db uploads
+flask run --host=0.0.0.0 --port=8080
+```
+
+The app is then available at `http://localhost:8080`. Routes include `/login`, `/register`, `/dashboard`, `/create_invoice`, `/businesses`, `/clients`, etc.
+
+### Running tests
+
+```bash
+source venv/bin/activate
+mkdir -p instance/db
+python -m pytest tests/ -v --ignore=tests/test_invoice_draft_api.py
+```
+
+**Known issues (pre-existing):**
+- `tests/test_invoice_draft_api.py` has a broken import (`from app import app` — `app.py` does not export an `app` object; the app is created in `app_factory.py`). Skip this file with `--ignore`.
+- 6 tests in `test_items.py` fail due to raw SQL strings passed to SQLAlchemy session without `text()` wrapper. These are pre-existing code bugs, not environment issues.
+
+### Linting
+
+```bash
+source venv/bin/activate
+flake8 --max-line-length=200 .
+black --check .
+```
+
+Pre-existing lint warnings exist (unused imports, formatting). These are in the existing codebase.
+
+### Key gotchas
+
+- The module-level `app = create_app()` in `app_factory.py` runs on import and tries to create the SQLite DB file. Ensure `instance/db/` directory exists before importing or running.
+- The `docker-compose.dev.yml` sets `FLASK_APP=app.py` but the correct entry point is `app_factory.py`. When running locally (outside Docker), always set `FLASK_APP=app_factory.py`.
+- The app uses `APPLICATION_ROOT = '/invoice'` but when running locally without a reverse proxy, routes work without the `/invoice` prefix.
+- Google Maps API key is optional; the app works fully without it (address autocomplete is just disabled).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,5 @@ Pre-existing lint warnings exist (unused imports, formatting). These are in the 
 - The `docker-compose.dev.yml` sets `FLASK_APP=app.py` but the correct entry point is `app_factory.py`. When running locally (outside Docker), always set `FLASK_APP=app_factory.py`.
 - The app uses `APPLICATION_ROOT = '/invoice'` but when running locally without a reverse proxy, routes work without the `/invoice` prefix.
 - Google Maps API key is optional; the app works fully without it (address autocomplete is just disabled).
+- WeasyPrint 62.0 requires `pydyf<0.12` (0.11.x). If pydyf 0.12+ is installed, PDF generation fails with `AttributeError: 'super' object has no attribute 'transform'`. The update script pins `pydyf<0.12` to prevent this.
+- After changing Python dependencies, the Flask dev server must be fully restarted (not just hot-reloaded) to pick up the changes.

--- a/app.py
+++ b/app.py
@@ -827,6 +827,7 @@ def register_routes(app):
             flash('Item removed successfully!')
         return redirect(url_for_with_prefix('item_details'))
 
+    @app.route('/get_company/<int:company_id>')
     @app.route('/invoice/get_company/<int:company_id>')
     @login_required
     def get_company(company_id):
@@ -851,6 +852,7 @@ def register_routes(app):
             return jsonify(client.to_dict())
         return jsonify({'error': 'Client not found'}), 404
 
+    @app.route('/check_invoice_number/<invoice_number>')
     @app.route('/invoice/check_invoice_number/<invoice_number>')
     @login_required
     def check_invoice_number(invoice_number):
@@ -950,6 +952,8 @@ def register_routes(app):
             app.logger.error(f"Error clearing tax rates: {str(e)}")
             return jsonify({'success': False, 'error': str(e)})
 
+    @app.route('/api/sales-tax', methods=['POST'])
+    @app.route('/create_sales_tax_rate', methods=['POST'])
     @app.route('/invoice/create_sales_tax_rate', methods=['POST'])
     @login_required
     def create_sales_tax_rate():
@@ -1413,6 +1417,7 @@ def register_routes(app):
     app.jinja_env.globals.update(url_for_with_prefix=url_for_with_prefix) 
 
     # Register API routes
+    @app.route('/api/items')
     @app.route('/invoice/api/items')
     @login_required
     def get_items():
@@ -1423,6 +1428,7 @@ def register_routes(app):
             'price': float(item.unit_price)
         } for item in items])
 
+    @app.route('/api/labor_items')
     @app.route('/invoice/api/labor_items')
     @login_required
     def get_labor_items():

--- a/templates/create_invoice.html
+++ b/templates/create_invoice.html
@@ -765,7 +765,7 @@
                     lineItem.dataset.taxId = item.taxId;
                     
                     // Fetch the tax rate details to get the description
-                    fetch('/api/sales-tax')
+                    fetch(`${APP_ROOT}/api/sales-tax`)
                         .then(response => response.json())
                         .then(rates => {
                             const taxRate = rates.find(r => r.id === parseInt(item.taxId));
@@ -944,7 +944,7 @@
             return;
         }
 
-        fetch(`${APP_ROOT}/invoice/get_company/${value}`)
+        fetch(`${APP_ROOT}/get_company/${value}`)
             .then(response => response.json())
             .then(company => {
                 // Update all company details
@@ -1019,7 +1019,7 @@
             sel.value = value;
         });
 
-        fetch(`${APP_ROOT}/invoice/get_client/${value}`)
+        fetch(`${APP_ROOT}/get_client/${value}`)
             .then(response => {
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
@@ -1687,7 +1687,7 @@
         dialog.style.display = 'block';
         
         // Load existing tax rates
-        fetch('/api/sales-tax')
+        fetch(`${APP_ROOT}/api/sales-tax`)
             .then(response => response.json())
             .then(rates => {
                 const select = document.getElementById('salesTaxSelect');
@@ -1719,7 +1719,7 @@
     function handleSalesTaxSelection(select) {
         if (select.value === 'clear') {
             if (confirm('Are you sure you want to clear all saved tax rates? This action cannot be undone.')) {
-                fetch('/api/sales-tax', {
+                fetch(`${APP_ROOT}/api/sales-tax`, {
                     method: 'DELETE'
                 })
                 .then(response => {
@@ -1752,7 +1752,7 @@
         // Calculate and display tax amount in real-time when a rate is selected
         if (select.value && select.value !== 'new') {
             const appliesTo = document.getElementById('taxAppliesTo').value;
-            fetch('/api/sales-tax')
+            fetch(`${APP_ROOT}/api/sales-tax`)
                 .then(response => response.json())
                 .then(rates => {
                     const selectedRate = rates.find(r => r.id === parseInt(select.value));
@@ -1811,7 +1811,7 @@
             }
             
             try {
-                const response = await fetch('/api/sales-tax', {
+                const response = await fetch(`${APP_ROOT}/api/sales-tax`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -1839,7 +1839,7 @@
         } else if (select.value) {
             // Use existing tax rate
             try {
-                const response = await fetch('/api/sales-tax');
+                const response = await fetch(`${APP_ROOT}/api/sales-tax`);
                 const rates = await response.json();
                 const selectedRate = rates.find(r => r.id === parseInt(select.value));
                 if (selectedRate) {
@@ -1928,7 +1928,7 @@
         
         // Pre-select the tax rate
         const select = document.getElementById('salesTaxSelect');
-        fetch('/api/sales-tax')
+        fetch(`${APP_ROOT}/api/sales-tax`)
             .then(response => response.json())
             .then(rates => {
                 const matchingRate = rates.find(r => r.rate === parseFloat(rate));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Fix: API route prefix mismatch breaking items/labor/tax behind reverse proxy

Users reported "Failed to load labor items" errors on the production server (hromp.com). Root cause: several API routes only had the `/invoice/`-prefixed path (e.g. `/invoice/api/labor_items`) but no unprefixed alias. Behind Nginx with `SCRIPT_NAME=/invoice`, Flask receives the path *without* the prefix (e.g. `/api/labor_items`), so the prefixed-only routes returned 404.

**Confirmed on production:** `curl https://hromp.com/invoice/api/labor_items` returns **404**.

#### Backend fixes (`app.py`)
- Add unprefixed route aliases for `get_items`, `get_labor_items`, `get_company`, `check_invoice_number`, and `create_sales_tax_rate` — matching the dual-route pattern already used by `invoice-draft` endpoints.

#### Frontend fixes (`templates/create_invoice.html`)
- Fix double-prefix bug: `get_company` and `get_client` fetches used `${APP_ROOT}/invoice/get_company/...` producing `/invoice/invoice/get_company/...`. Changed to `${APP_ROOT}/get_company/...`.
- Replace 7 hardcoded `/api/sales-tax` fetch paths with `${APP_ROOT}/api/sales-tax` so requests route through the Nginx `/invoice/` location block in production.

### Also includes: AGENTS.md for cloud dev environment

- System dependency requirements (WeasyPrint native libs)
- Dev server startup commands and test execution
- Key gotchas (db directory, FLASK_APP entry point, WeasyPrint/pydyf compatibility)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f642fcac-a139-408c-a033-96425fb8f4c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f642fcac-a139-408c-a033-96425fb8f4c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

